### PR TITLE
Debug change field name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .idea
 *~
 advancedbrowser/meta.json
+/meta.json

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Version: 2.4
+# See github page to report issues or to contribute:
+# https://github.com/hssm/advanced-browser
+
+from . import advancedbrowser


### PR DESCRIPTION
When you added a new field name or edited an existing one, the add-on
led to an error message because this field was not in customColumns.
Instead I now use getCustomColumn, which add the field to
customColumns if it is missing