### PR TITLE
Add schema

### DIFF
--- a/advancedbrowser/config.schema.json
+++ b/advancedbrowser/config.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Advanced browser",
+  "properties": {
+    "Use a single list for fields": {
+      "type": "boolean",
+      "default": false
+    },
+    "Show internal fields": {
+      "type": "boolean",
+      "default": false
+    },
+    "Keyboard shortcut for note browser mode": {
+      "type": "string",
+      "pattern": "^((([Cc][Tt][Rr][Ll]|[Aa][Ll][Tt]|[Ss][Hh][Ii][Ff][Tt])\\+){0,3}[a-zA-Z0-9])?$",
+      "default": "Ctrl+Alt+N"
+    }
+  }
+}

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,1 @@
+advancedbrowser/config.schema.json


### PR DESCRIPTION
Anki 2.1.21 will add validation against json schema. I'm thus add-in schemas to add-on which I like.
Furthermore, I'm creating an add-on which use schema to automatically create graphical forms for user. So they can click on checkbox to set the boolean, and enter the string for shortcut without changing anything else