### PR TITLE
In overdue, show correctly the number of card

### DIFF
--- a/advancedbrowser/advancedbrowser/custom_fields.py
+++ b/advancedbrowser/advancedbrowser/custom_fields.py
@@ -123,7 +123,7 @@ class CustomFields:
         def cOverdueIvl(c, n, t):
             val = self.valueForOverdue(c.odid, c.queue, c.type, c.due)
             if val:
-                return mw.col.backend.format_time_span(val, context=FormatTimeSpanContext.INTERVALS)
+                return mw.col.backend.format_time_span(val * 24 * 60 * 60, context=FormatTimeSpanContext.INTERVALS)
 
         # fixme: this will need to be converted into an sql case statement
         srt = ("(select due " #valueForOverdue(odid, queue, type, due) "


### PR DESCRIPTION
"val" is in day, and `mw.col.backend.format_time_span` take seconds