### PR TITLE
Update for 2.1.45

### DIFF
--- a/advancedbrowser/advancedbrowser/advanced_fields.py
+++ b/advancedbrowser/advancedbrowser/advanced_fields.py
@@ -7,11 +7,11 @@ import time
 from anki.cards import Card
 from anki.consts import *
 from anki.hooks import addHook
-
-from aqt.utils import tr
 from anki.lang import FormatTimeSpan as FormatTimeSpanContext
+
 from aqt import *
-from aqt.utils import askUser
+from aqt.operations.card import set_card_flag
+from aqt.utils import askUser, tr
 
 
 class AdvancedFields:
@@ -323,20 +323,18 @@ class AdvancedFields:
             try:
                 value = int(value)
             except ValueError:
-                value = {"":0, "no":0,"red":1, "orange":2, "green":3, "blue":4}.get(value.strip().lower())
+                value = {"":0, "no":0,"red":1, "orange":2, "green":3, "blue":4, "pink":5, "turquoise":6, "purple":7}.get(value.strip().lower())
                 if value is None:
                     return False
-            if not 0 <= value <= 4:
+            if not 0 <= value <= 7:
                 return False
-            c.setUserFlag(value)
+            set_card_flag(parent=advBrowser.browser, card_ids=[c.id], flag=value).run_in_background()
             return True
 
         cc = advBrowser.newCustomColumn(
             type="cflags",
             name="Flag",
-            onData=lambda c, n, t: {1: tr(TR.ACTIONS_RED_FLAG), 2:tr(TR.ACTIONS_ORANGE_FLAG),
-                                    3: tr(TR.ACTIONS_GREEN_FLAG), 4:tr(TR.ACTIONS_BLUE_FLAG)}
-                .get(c.flags, None),
+            onData=lambda c, n, t: mw.flags.get_flag(c.flags).label if c.flags else None,
             onSort=lambda: "(case when c.flags = 0 then null else c.flags end) asc nulls last",
             setData=setData,
         )

--- a/advancedbrowser/advancedbrowser/advanced_fields.py
+++ b/advancedbrowser/advancedbrowser/advanced_fields.py
@@ -67,7 +67,7 @@ class AdvancedFields:
             avgtime = mw.col.db.scalar(
                 "select avg(time)/1000.0 from revlog where cid = ?", c.id)
             if avgtime:
-                return mw.col.backend.format_time_span(avgtime)
+                return mw.col.format_timespan(avgtime)
             return None
 
         cc = advBrowser.newCustomColumn(
@@ -84,7 +84,7 @@ class AdvancedFields:
             tottime = mw.col.db.scalar(
                 "select sum(time)/1000.0 from revlog where cid = ?", c.id)
             if tottime:
-                return mw.col.backend.format_time_span(tottime)
+                return mw.col.format_timespan(tottime)
             return None
 
         cc = advBrowser.newCustomColumn(
@@ -102,7 +102,7 @@ class AdvancedFields:
                 "select time/1000.0 from revlog where cid = ? "
                 "order by time asc limit 1", c.id)
             if tm:
-                return mw.col.backend.format_time_span(tm)
+                return mw.col.format_timespan(tm)
             return None
 
         # Note: capital ASC required to avoid search+replace
@@ -124,7 +124,7 @@ class AdvancedFields:
                 "select time/1000.0 from revlog where cid = ? "
                 "order by time desc limit 1", c.id)
             if tm:
-                return mw.col.backend.format_time_span(tm)
+                return mw.col.format_timespan(tm)
             return None
 
         srt = ("(select time/1000.0 from revlog where cid = c.id "
@@ -143,7 +143,7 @@ class AdvancedFields:
         def cOverdueIvl(c, n, t):
             val = self.valueForOverdue(c.odid, c.queue, c.type, c.due)
             if val:
-                return mw.col.backend.format_time_span(val * 24 * 60 * 60, context=FormatTimeSpanContext.INTERVALS)
+                return mw.col.format_timespan(val * 24 * 60 * 60, context=FormatTimeSpanContext.INTERVALS)
 
         srt = (f"""
         select
@@ -176,9 +176,9 @@ class AdvancedFields:
             elif ivl == 0:
                 return "0 days"
             elif ivl > 0:
-                return mw.col.backend.format_time_span(ivl*86400, context=FormatTimeSpanContext.INTERVALS)
+                return mw.col.format_timespan(ivl*86400, context=FormatTimeSpanContext.INTERVALS)
             else:
-                return mw.col.backend.format_time_span(-ivl, context=FormatTimeSpanContext.INTERVALS)
+                return mw.col.format_timespan(-ivl, context=FormatTimeSpanContext.INTERVALS)
 
         srt = ("(select ivl from revlog where cid = c.id "
                "order by id desc limit 1 offset 1) asc nulls last")
@@ -214,7 +214,7 @@ class AdvancedFields:
                 "select time/1000.0 from revlog where cid = ? "
                 "order by id desc limit 1", c.id)
             if time:
-                return mw.col.backend.format_time_span(time)
+                return mw.col.format_timespan(time)
             return None
 
         srt = ("(select time/1000.0 from revlog where cid = c.id "

--- a/advancedbrowser/advancedbrowser/basic_fields.py
+++ b/advancedbrowser/advancedbrowser/basic_fields.py
@@ -28,7 +28,7 @@ class BasicFields:
 
         def setData(c: Card, value: str):
             n = c.note()
-            m = n.model()
+            m = n.note_type()
             if m["type"] == MODEL_CLOZE:
                 tmpl = m["tmpls"][0]
                 tmpl_name = tmpl["name"]

--- a/advancedbrowser/advancedbrowser/core.py
+++ b/advancedbrowser/advancedbrowser/core.py
@@ -3,222 +3,50 @@
 # https://github.com/hssm/advanced-browser
 
 import time
-from PyQt5 import QtWidgets
-from anki.hooks import runHook
+
+from anki.collection import BrowserColumns, Collection
+from anki.hooks import runHook, wrap
 from aqt import *
 from aqt import gui_hooks
-from aqt.browser import Browser, DataModel, SearchContext, StatusDelegate
-from operator import itemgetter
+from aqt.browser import Browser, Column as BuiltinColumn, DataModel, SearchContext, CardState, NoteState
 
 from . import config
 from .column import Column, CustomColumn
 from .contextmenu import ContextMenu
 
-CONF_KEY = 'advbrowse_activeCols'
+
+CONF_KEY_PREFIX = 'advbrowse_'
 
 
-class AdvancedDataModel(DataModel):
-
-    def __init__(self, browser):
-        """Load our copy of the active columns and suppress the built-in one.
-
-        This function runs after custom columns have been registered, so our
-        list of custom types has already been populated."""
-        super(AdvancedDataModel, self).__init__(browser)
-
-        gui_hooks.browser_will_search.append(self.willSearch)
-        gui_hooks.browser_did_search.append(self.didSearch)
-
-        # Keep a reference to this function; we need the original later
-        self._columnData = DataModel.columnData
-
-        # Model->flds cache, similar to self.cardObjs
-        self.modelFldObjs = {}
-
-        # Keep a copy of the original active columns to restore on closing.
-        self.origActiveCols = list(self.activeCols)
-
-        configuredCols = self.browser.mw.col.get_config(CONF_KEY)
-        if configuredCols:
-            # We've used this add-on before and have a configured list of columns.
-            # Adjust activeCols to reflect it.
-
-            # Make sure the columns we are loading are still valid. If not, we
-            # just ignore them. This guards against the event that a column is
-            # removed or renamed.
-            #
-            # The list of valid columns are the built-in ones + our custom ones.
-            valids = set([c[0] for c in browser.columns] +
-                         list(browser.customTypes.keys()))
-
-            self.activeCols = [col for col in configuredCols if col in valids]
-
-            # Also make sure the sortType is valid
-            if self.browser.mw.col.get_config('sortType') not in valids:
-                self.browser.mw.col.set_config('sortType', 'noteFld')
-                # If there is no sorted column, we add the 'Sort Field' column
-                # and sort on that. This method is one way to guarantee that we
-                # always start with at least one valid column.
-                if 'noteFld' not in self.activeCols:
-                    self.activeCols.append('noteFld')
-
-    def getFld(self, index):
-        """"
-        Field cache, similar to getCard().
-        This method only exists to make fetching field settings efficient in
-        order to determine if it is RTL.
-        """
-        model = self.getCard(index).note().model()
-        id = model['id']
-        fldName = self.activeCols[index.column()]
-        if fldName.startswith("_field_"):
-            fldName = fldName[7:]
-        else:
-            # This custom column is not a field column
-            return None
-        if id not in self.modelFldObjs:
-            self.modelFldObjs[id] = {}
-        if fldName not in self.modelFldObjs[id]:
-            flds = [f for f in model['flds'] if f['name'] == fldName]
-            if len(flds) == 0:
-                # This model does not have a field with that name
-                self.modelFldObjs[id][fldName] = None
-            else:
-                self.modelFldObjs[id][fldName] = flds[0]
-        return self.modelFldObjs[id][fldName]
-
-    def data(self, index, role):
-        if role == Qt.TextAlignmentRole:
-            col = self.activeCols[index.column()]
-            if col in self.browser.customTypes:
-                # If this is one of our columns, use custom alignment rules
-                align = Qt.AlignVCenter | Qt.AlignLeft
-                return align
-        return super(AdvancedDataModel, self).data(index, role)
-
-    def columnData(self, index):
-        # Try to handle built-in Anki column
-        returned = self._columnData(self, index)
-        if returned:
-            return returned
-
-        # If Anki can't handle it, it must be one of ours.
-        col = index.column()
-        type = self.columnType(col)
-        if type in self.browser.customTypes:
-            c = self.getCard(index)
-            n = c.note()
-            try:
-                return self.browser.customTypes[type].onData(c, n, type)
-            except:
-                return "{error}"
-
-    def willSearch(self, ctx: SearchContext):
-        # If the column is not a custom one handled by this add-on, do it
-        # internally.
-        cTypes = self.browser.customTypes
-        type = self.col.get_config('sortType')
-        if type not in cTypes:
-            return
-
-        cc = cTypes[type]
-        order = cc.onSort()
-        if not order:
-            ctx.order = None
-        else:
-            if self.col.get_config('sortBackwards'):
-                order = order.replace(" asc", " desc")
-            ctx.order = order
-
-        self.time = time.time()
-
-        # If this column relies on a temporary table for sorting, build it now
-        if cc.sortTableFunction:
-            cc.sortTableFunction()
-
-
-
-    def didSearch(self, ctx: SearchContext):
-        #print("Search took: %dms" % ((time.time() - self.time)*1000))
-        pass
-
-
-    def flags(self, index):
-        s = super().flags(index)
-        if config.getSelectable() != "No interaction":
-            s = s | Qt.ItemIsEditable
-        return s
-
-    def setData(self, index, value, role):
-        if role not in (Qt.DisplayRole, Qt.EditRole):
-            return False
-        old_value = self.columnData(index)
-        if value == old_value:
-            return False
-        col = index.column()
-        c = self.getCard(index)
-
-        type = self.columnType(col)
-        if type in self.browser.customTypes:
-            r = self.browser.customTypes[type].setData(c, value)
-            if r is True:
-                self.dataChanged.emit(index, index, [role])
-            return r
-        else:
-            return False
-
-
-class AdvancedStatusDelegate(StatusDelegate):
-    def paint(self, painter, option, index):
-        fld = self.browser.model.getFld(index)
-        if fld and fld['rtl']:
-            option.direction = Qt.RightToLeft
-        return super(AdvancedStatusDelegate, self).paint(painter, option, index)
-
-
-class AdvancedBrowser(Browser):
+class AdvancedBrowser:
     """Maintains state for the add-on."""
 
-    def newBrowserInit(self, mw, card, search):
-        """Init stub to allow us to construct a Browser without doing
-        the setup until we need to."""
-        QMainWindow.__init__(self, None, Qt.Window)
-
-    def __init__(self, mw, card=None, search=None):
-        # Override Browser __init_. We manually invoke the original after
-        # we use our stub one. This is to work around the fact that super
-        # needs to be called on Browser before its methods can be invoked,
-        # which add-ons need to do in the hook.
-        origInit = Browser.__init__
-        Browser.__init__ = self.newBrowserInit
-        super(AdvancedBrowser, self).__init__(mw, card, search)
-
+    def __init__(self, mw):
+        self.mw = mw
         # A list of columns to exclude when building the final column list.
         self.columnsToRemove = []
-
         # CustomColumn objects maintained by this add-on.
         # {type -> CustomColumn}
         self.customTypes = {}
+        # Model->flds cache, similar to self.cardObjs
+        self.modelFldObjs = {}
+
+    def _load(self, browser):
+        self.browser = browser
+        self.table = browser.table
+        self.editor = browser.editor
+        self.col = browser.col
 
         # Let add-ons add or remove columns now.
         runHook("advBrowserLoaded", self)
 
-        # Build the actual browser, which now has our state in it,
-        # and restore constructor.
-        origInit(self, mw, card, search)
-        Browser.__init__ = origInit
-
-        # Remove excluded columns after the browser is built. Doing it here
-        # is mostly a compromise in complexity. The alternative is to
-        # rewrite the order of the original __init__ method, which is
-        # cumbersome and error-prone.
         self.__removeColumns()
+        self.setupColumns()
 
         # Workaround for double-saving (see closeEvent)
         self.saveEvent = False
-        if config.getSelectable() == "Editable":
-            self.form.tableView.setEditTriggers(
-                QtWidgets.QAbstractItemView.DoubleClicked)
+        if config.getSelectable() != "No interaction":
+            self.table._view.setEditTriggers(self.table._view.DoubleClicked)
 
     def newCustomColumn(self, type, name, onData, onSort=None,
                         setData=None, sortTableFunction=False):
@@ -241,47 +69,116 @@ class AdvancedBrowser(Browser):
             if type in self.customTypes:
                 self.customTypes.pop(type, None)
 
-            # Built-in list is a list of tuples.
-            for tup in list(self.columns):
-                if tup[0] == type:
-                    self.removedBuiltIns.append(tup)
-                    self.columns.remove(tup)
+            # Columns are a dict of str keys and builtin columns
+            for column in self.table._model.columns:
+                if column == type:
+                    self.removedBuiltIns.append(column)
+                    del self.table._model.columns[column]
 
             # Remove it from the active columns if it's there.
-            if type in self.model.activeCols:
-                self.toggleField(type)
-
-    def setupTable(self):
-        """Some customizations to the table view"""
-        super(AdvancedBrowser, self).setupTable()
-        self.form.tableView.setHorizontalScrollMode(
-            QAbstractItemView.ScrollPerPixel)
-        self.form.tableView.setItemDelegate(
-            AdvancedStatusDelegate(self, self.model))
+            if type in self.table._state.active_columns:
+                self.table._on_column_toggled(False, type)
 
     def setupColumns(self):
         """Build a list of candidate columns. We extend the internal
         self.columns list with our custom types."""
-        super(AdvancedBrowser, self).setupColumns()
-        for type in self.customTypes:
-            self.columns.append((self.customTypes[type].type,
-                                 self.customTypes[type].name))
-        self.columns.sort(key=itemgetter(1))
+        for key, column in self.customTypes.items():
+            self.table._model.columns[key] = BuiltinColumn(
+                key=key,
+                cards_mode_label=column.name,
+                notes_mode_label=column.name,
+                sorting=BrowserColumns.SORTING_NORMAL if column.onSort() else BrowserColumns.SORTING_NONE,
+                uses_cell_font=False,
+                alignment=BrowserColumns.ALIGNMENT_CENTER,
+            )
 
-    def onHeaderContext(self, pos):
+    def willSearch(self, ctx: SearchContext):
+        # If the order is a custom column, apply the column's sorting
+        if type(ctx.order) == BuiltinColumn and (cc := self.customTypes.get(ctx.order.key)):
+            order = cc.onSort()
+            if not order:
+                ctx.order = None
+            else:
+                if self.table._state.sort_backwards:
+                    order = order.replace(" asc", " desc")
+                ctx.order = order
+
+            self.time = time.time()
+
+            # If this column relies on a temporary table for sorting, build it now
+            if cc.sortTableFunction:
+                cc.sortTableFunction()
+
+    def didSearch(self, ctx: SearchContext):
+        #print("Search took: %dms" % ((time.time() - self.time)*1000))
+        pass
+
+    def _column_data(self, item, is_notes_mode, row, active_columns):
+        """Fill in data of custom columns."""
+        c = self.table._state.get_card(item)
+        n = self.table._state.get_note(item)
+        for index, key in enumerate(active_columns):
+            # Filter for custom types with a data function
+            if (custom_type := self.customTypes.get(key)) is None:
+                continue
+            if custom_type.onData is None:
+                continue
+
+            # Get cell content
+            try:
+                row.cells[index].text = custom_type.onData(c, n, key)
+            except Exception as error:
+                row.cells[index].text = f"{error}"
+
+            # Get rtl info for field cells
+            if key.startswith("_field_"):
+                fldName = key[7:]
+                model = n.note_type()
+                model_id = model["id"]
+                if model_id not in self.modelFldObjs:
+                    self.modelFldObjs[model_id] = {}
+                if fldName not in self.modelFldObjs[model_id]:
+                    flds = [f for f in model['flds'] if f['name'] == fldName]
+                    if len(flds) == 0:
+                        # This model does not have a field with that name
+                        self.modelFldObjs[model_id][fldName] = None
+                    else:
+                        self.modelFldObjs[model_id][fldName] = flds[0]
+                fld = self.modelFldObjs[model_id][fldName]
+                row.cells[index].is_rtl = bool(fld and fld["rtl"])
+
+    def setData(self, model, index, value, role):
+        if role not in (Qt.DisplayRole, Qt.EditRole):
+            return False
+        if config.getSelectable() != "Editable":
+            return False
+        old_value = model.get_cell(index).text
+        if value == old_value:
+            return False
+        c = model.get_card(index)
+
+        type = model.column_at(index).key
+        if type in self.customTypes:
+            r = self.customTypes[type].setData(c, value)
+            if r is True:
+                model.dataChanged.emit(index, index, [role])
+            return r
+        else:
+            return False
+
+    def _on_header_context(self, table, pos):
         """Override the original onHeaderContext. We are responsible for
         building the entire menu, so we include the original columns as
         well."""
 
-        gpos = self.form.tableView.mapToGlobal(pos)
+        gpos = table._view.mapToGlobal(pos)
         main = QMenu()
         contextMenu = ContextMenu()
 
         # We are also a client and we need to add the built-in columns first.
-        for item in self.columns:
-            type, name = item
-            if type not in self.customTypes:
-                contextMenu.addItem(Column(type, name))
+        for key, column in table._model.columns.items():
+            if key not in self.customTypes:
+                contextMenu.addItem(Column(key, table._state.column_label(column)))
 
         # Now let clients do theirs.
         runHook("advBrowserBuildContext", contextMenu)
@@ -289,8 +186,8 @@ class AdvancedBrowser(Browser):
         def addCheckableAction(menu, type, name):
             a = menu.addAction(name)
             a.setCheckable(True)
-            a.setChecked(type in self.model.activeCols)
-            a.toggled.connect(lambda b, t=type: self.toggleField(t))
+            a.setChecked(table._model.active_column_index(type) is not None)
+            a.toggled.connect(lambda checked, key=type: table._on_column_toggled(checked, key))
 
         # For some reason, sub menus aren't added if we don't keep a
         # reference to them until exec, so keep them in this list.
@@ -312,43 +209,134 @@ class AdvancedBrowser(Browser):
 
         main.exec_(gpos)
 
-    def closeEvent(self, evt):
-        """Preserve our column state in a collection preference."""
 
-        # After we save our columns, we restore activeCols to the original
-        # copy that Anki maintains and allow it to resume its own save
-        # routine unhindered by our unsupported columns.
-        # When the add-on resumes on next startup, we replace activecols
-        # again with our own version.
-        # NOTE: we use a flag to check if we have performed this action before
-        # as a workaround to this function being called twice and overriding
-        # the custom columns with the original columns.
+# Table model expansions for editable cells
+################################################################################
 
-        if not self.saveEvent:
-            # Save ours
-            self.mw.col.set_config(CONF_KEY, self.model.activeCols)
-            # Restore old
-            self.model.activeCols = self.model.origActiveCols
-            # Restore built-in columns we removed
-            self.columns.extend(self.removedBuiltIns or [])
-            # Only save once
-            self.saveEvent = True
+def wrap_flags(self, index, _old):
+    s = _old(self, index)
+    if config.getSelectable() != "No interaction":
+        s |=  Qt.ItemIsEditable
+    return s
 
-        gui_hooks.browser_will_search.remove(self.model.willSearch)
-        gui_hooks.browser_did_search.remove(self.model.didSearch)
 
-        # Let Anki do its stuff now
-        super(AdvancedBrowser, self).closeEvent(evt)
+def wrap_data(self, index, role, _old):
+    if role == Qt.EditRole:
+        role = Qt.DisplayRole
+    return _old(self, index, role)
 
-    def _onSortChanged(self, idx, ord):
-        type = self.model.activeCols[idx]
-        if type in self.customTypes:
-            if self.col.get_config('sortType') == type:
-                self.col.set_config('sortType', "")
-        super(AdvancedBrowser, self)._onSortChanged(idx, ord)
 
-# Override DataModel with our subclass
-aqt.browser.DataModel = AdvancedDataModel
+# Config getting and setting
+################################################################################
 
-# Make Anki load AdvancedBrowser instead of the original Browser
-aqt.dialogs._dialogs['Browser'] = [AdvancedBrowser, None]
+def _set_advanced_browser_card_columns(self, columns):
+    self.set_config(CONF_KEY_PREFIX + "activeCols", columns)
+    self._backend.set_active_browser_columns(columns)
+
+
+def _set_advanced_browser_note_columns(self, columns):
+    self.set_config(CONF_KEY_PREFIX + "activeNoteCols", columns)
+    self._backend.set_active_browser_columns(columns)
+
+
+def _load_advanced_browser_card_columns(self):
+    columns = self.get_config(CONF_KEY_PREFIX + "activeCols") or self.get_config(
+        "activeCols", ["noteFld", "template", "cardDue", "deck"])
+    self._backend.set_active_browser_columns(columns)
+    return columns
+
+
+def _load_advanced_browser_note_columns(self):
+    columns = self.get_config(CONF_KEY_PREFIX + "activeNoteCols") or self.get_config(
+        "activeNoteCols", ["noteFld", "note", "noteCards", "noteTags"])
+    self._backend.set_active_browser_columns(columns)
+    return columns
+
+
+class AdvancedCardState(CardState):
+    def __init__(self, col):
+        super().__init__(col)
+        self.config_key_prefix = CONF_KEY_PREFIX + self.config_key_prefix
+        self._sort_column = self.col.get_config(
+            CONF_KEY_PREFIX + "sortType", self._sort_column)
+        self._sort_backwards = self.col.get_config(
+            CONF_KEY_PREFIX + "sortBackwards", self._sort_backwards)
+
+    @property
+    def sort_column(self) -> str:
+        return self._sort_column
+
+    @sort_column.setter
+    def sort_column(self, column):
+        self.col.set_config(CONF_KEY_PREFIX + "sortType", column)
+        self._sort_column = column
+
+    @property
+    def sort_backwards(self) -> bool:
+        return self._sort_backwards
+
+    @sort_backwards.setter
+    def sort_backwards(self, order):
+        self.col.set_config(CONF_KEY_PREFIX + "sortBackwards", order)
+        self._sort_backwards = order
+
+
+class AdvancedNoteState(NoteState):
+    def __init__(self, col):
+        super().__init__(col)
+        self.config_key_prefix = CONF_KEY_PREFIX + self.config_key_prefix
+        # Override loaded config if there are configs for advanced browser
+        self._sort_column = self.col.get_config(
+            CONF_KEY_PREFIX + "noteSortType", self._sort_column)
+        self._sort_backwards = self.col.get_config(
+            CONF_KEY_PREFIX + "noteSortBackwards", self._sort_backwards)
+
+    @property
+    def sort_column(self) -> str:
+        return self._sort_column
+
+    @sort_column.setter
+    def sort_column(self, column):
+        self.col.set_config(CONF_KEY_PREFIX + "noteSortType", column)
+        self._sort_column = column
+
+    @property
+    def sort_backwards(self) -> bool:
+        return self._sort_backwards
+
+    @sort_backwards.setter
+    def sort_backwards(self, order):
+        self.col.set_config(CONF_KEY_PREFIX + "sortBackwards", order)
+        self._sort_backwards = order
+
+
+################################################################################
+
+# Override methods to use our own config keys instead, when loading or setting configs 
+Collection.set_browser_card_columns = _set_advanced_browser_card_columns
+Collection.set_browser_note_columns = _set_advanced_browser_note_columns
+Collection.load_browser_card_columns = _load_advanced_browser_card_columns
+Collection.load_browser_note_columns = _load_advanced_browser_note_columns
+aqt.browser.table.state.CardState = AdvancedCardState
+aqt.browser.table.state.NoteState = AdvancedNoteState
+
+# Init AdvancedBrowser
+advanced_browser = AdvancedBrowser(mw)
+
+# Hooks
+gui_hooks.browser_will_show.append(advanced_browser._load)
+gui_hooks.browser_will_search.append(advanced_browser.willSearch)
+gui_hooks.browser_did_search.append(advanced_browser.didSearch)
+gui_hooks.browser_did_fetch_row.append(advanced_browser._column_data)
+
+# Override table's context menu to include our own columns
+aqt.browser.Table._on_header_context = lambda *args: advanced_browser._on_header_context(*args)
+
+# Override table model flags to make cells editable if applicable
+DataModel.flags = wrap(DataModel.flags, wrap_flags, "around")
+
+# Override table model data to return data in case of edit role
+DataModel.data = wrap(DataModel.data, wrap_data, "around")
+
+# Add setData() to table model (Qt API)
+DataModel.setData = lambda *args: advanced_browser.setData(*args)

--- a/advancedbrowser/advancedbrowser/core.py
+++ b/advancedbrowser/advancedbrowser/core.py
@@ -4,11 +4,12 @@
 
 import time
 
-from anki.collection import BrowserColumns, Collection
+from anki.collection import BrowserColumns
+from anki.browser import BrowserConfig
 from anki.hooks import runHook, wrap
 from aqt import *
 from aqt import gui_hooks
-from aqt.browser import Browser, Column as BuiltinColumn, DataModel, SearchContext, CardState, NoteState
+from aqt.browser import Column as BuiltinColumn, DataModel, SearchContext, CardState, NoteState
 
 from . import config
 from .column import Column, CustomColumn
@@ -226,99 +227,17 @@ def wrap_data(self, index, role, _old):
     return _old(self, index, role)
 
 
-# Config getting and setting
 ################################################################################
 
-def _set_advanced_browser_card_columns(self, columns):
-    self.set_config(CONF_KEY_PREFIX + "activeCols", columns)
-    self._backend.set_active_browser_columns(columns)
-
-
-def _set_advanced_browser_note_columns(self, columns):
-    self.set_config(CONF_KEY_PREFIX + "activeNoteCols", columns)
-    self._backend.set_active_browser_columns(columns)
-
-
-def _load_advanced_browser_card_columns(self):
-    columns = self.get_config(CONF_KEY_PREFIX + "activeCols") or self.get_config(
-        "activeCols", ["noteFld", "template", "cardDue", "deck"])
-    self._backend.set_active_browser_columns(columns)
-    return columns
-
-
-def _load_advanced_browser_note_columns(self):
-    columns = self.get_config(CONF_KEY_PREFIX + "activeNoteCols") or self.get_config(
-        "activeNoteCols", ["noteFld", "note", "noteCards", "noteTags"])
-    self._backend.set_active_browser_columns(columns)
-    return columns
-
-
-class AdvancedCardState(CardState):
-    def __init__(self, col):
-        super().__init__(col)
-        self.config_key_prefix = CONF_KEY_PREFIX + self.config_key_prefix
-        self._sort_column = self.col.get_config(
-            CONF_KEY_PREFIX + "sortType", self._sort_column)
-        self._sort_backwards = self.col.get_config(
-            CONF_KEY_PREFIX + "sortBackwards", self._sort_backwards)
-
-    @property
-    def sort_column(self) -> str:
-        return self._sort_column
-
-    @sort_column.setter
-    def sort_column(self, column):
-        self.col.set_config(CONF_KEY_PREFIX + "sortType", column)
-        self._sort_column = column
-
-    @property
-    def sort_backwards(self) -> bool:
-        return self._sort_backwards
-
-    @sort_backwards.setter
-    def sort_backwards(self, order):
-        self.col.set_config(CONF_KEY_PREFIX + "sortBackwards", order)
-        self._sort_backwards = order
-
-
-class AdvancedNoteState(NoteState):
-    def __init__(self, col):
-        super().__init__(col)
-        self.config_key_prefix = CONF_KEY_PREFIX + self.config_key_prefix
-        # Override loaded config if there are configs for advanced browser
-        self._sort_column = self.col.get_config(
-            CONF_KEY_PREFIX + "noteSortType", self._sort_column)
-        self._sort_backwards = self.col.get_config(
-            CONF_KEY_PREFIX + "noteSortBackwards", self._sort_backwards)
-
-    @property
-    def sort_column(self) -> str:
-        return self._sort_column
-
-    @sort_column.setter
-    def sort_column(self, column):
-        self.col.set_config(CONF_KEY_PREFIX + "noteSortType", column)
-        self._sort_column = column
-
-    @property
-    def sort_backwards(self) -> bool:
-        return self._sort_backwards
-
-    @sort_backwards.setter
-    def sort_backwards(self, order):
-        self.col.set_config(CONF_KEY_PREFIX + "sortBackwards", order)
-        self._sort_backwards = order
-
-
-################################################################################
-
-# Override methods to use our own config keys instead, when loading or setting configs 
-Collection.set_browser_card_columns = _set_advanced_browser_card_columns
-Collection.set_browser_note_columns = _set_advanced_browser_note_columns
-Collection.load_browser_card_columns = _load_advanced_browser_card_columns
-Collection.load_browser_note_columns = _load_advanced_browser_note_columns
-aqt.browser.table.state.CardState = AdvancedCardState
-aqt.browser.table.state.NoteState = AdvancedNoteState
+# Override config keys to use own set of config values
+CardState.GEOMETRY_KEY_PREFIX = CONF_KEY_PREFIX + CardState.GEOMETRY_KEY_PREFIX
+NoteState.GEOMETRY_KEY_PREFIX = CONF_KEY_PREFIX + NoteState.GEOMETRY_KEY_PREFIX
+BrowserConfig.ACTIVE_CARD_COLUMNS_KEY = CONF_KEY_PREFIX + BrowserConfig.ACTIVE_CARD_COLUMNS_KEY
+BrowserConfig.ACTIVE_NOTE_COLUMNS_KEY = CONF_KEY_PREFIX + BrowserConfig.ACTIVE_NOTE_COLUMNS_KEY
+BrowserConfig.CARDS_SORT_COLUMN_KEY = CONF_KEY_PREFIX + BrowserConfig.CARDS_SORT_COLUMN_KEY
+BrowserConfig.NOTES_SORT_COLUMN_KEY = CONF_KEY_PREFIX + BrowserConfig.NOTES_SORT_COLUMN_KEY
+BrowserConfig.CARDS_SORT_BACKWARDS_KEY = CONF_KEY_PREFIX + BrowserConfig.CARDS_SORT_BACKWARDS_KEY
+BrowserConfig.NOTES_SORT_BACKWARDS_KEY = CONF_KEY_PREFIX + BrowserConfig.NOTES_SORT_BACKWARDS_KEY
 
 # Init AdvancedBrowser
 advanced_browser = AdvancedBrowser(mw)

--- a/advancedbrowser/advancedbrowser/internal_fields.py
+++ b/advancedbrowser/advancedbrowser/internal_fields.py
@@ -222,7 +222,7 @@ class InternalFields:
             except ValueError:
                 return False
             n = c.note()
-            m = n.model()
+            m = n.note_type()
             if value < 0:
                 return False
             if m["type"] == MODEL_STD and value >= len(m["tmpls"]):

--- a/advancedbrowser/advancedbrowser/note_fields.py
+++ b/advancedbrowser/advancedbrowser/note_fields.py
@@ -44,12 +44,12 @@ class NoteFields:
         fldGroup = contextMenu.newSubMenu(" - Fields -")
         if getEachFieldInSingleList():
             # And an option for each fields
-            for model in mw.col.models.models.values():
+            for model in mw.col.models.all():
                 for fld in model['flds']:
                     fldGroup.addItem(self.customColumns[fld['name']])
         else:
             # And a sub-menu for each note type
-            for model in mw.col.models.models.values():
+            for model in mw.col.models.all():
                 modelGroup = fldGroup.newSubMenu(model['name'])
                 for fld in model['flds']:
                     modelGroup.addItem(self.customColumns[fld['name']])

--- a/advancedbrowser/advancedbrowser/note_fields.py
+++ b/advancedbrowser/advancedbrowser/note_fields.py
@@ -85,6 +85,7 @@ class NoteFields:
         def setData_(name):
             def setData(c: Card, value: str):
                 n = c.note()
+                m = n.note_type()
                 if not name in n:
                     showWarning(_("""The field "%s" does not belong to the note type "%s".""") % (
                         name, m["name"]))


### PR DESCRIPTION
With this PR, advanced browser can be run on the ~latest~ next beta (2.1.45b~6~7). See 01cb415 for some reasoning. Also closes #125 and fixes #123.
What this PR *doesn't* do:
- Fix the editing functions (with the exception of flags, 49b44ad).
- Make use of new columns, which allow customising alignment, sort order etc.
- Use aggregated data in notes mode. Instead, the data for the first card of each note is shown.
- ~Fix an issue, where the headers are not restored correctly the first time. I intend to address this after https://github.com/ankitects/anki/pull/1277 has been merged, which will allow us to drop most of the remaining monkey patching.~